### PR TITLE
Remove blur events and use tab keybinding

### DIFF
--- a/spec/src/search-bar.spec.js
+++ b/spec/src/search-bar.spec.js
@@ -76,7 +76,6 @@ describe('<SearchBar /> component', () => {
         value: baseProps.query,
         autoFocus: baseProps.doAutoFocus,
         onFocus: baseProps.onFocus,
-        onBlur: baseProps.onFocus,
         isFocused: baseProps.isFocused
       };
 

--- a/spec/src/search-input.spec.js
+++ b/spec/src/search-input.spec.js
@@ -17,7 +17,6 @@ const defaultProps = {
   doAutoFocus: false,
   isFocused: false,
   name: 'my-input',
-  onBlur: focusSpy,
   onChange: changeSpy,
   onFocus: focusSpy,
   value: ''
@@ -42,7 +41,6 @@ describe('<SearchInput />', () => {
       className: 'reactahead-inline-input',
       name: defaultProps.name,
       onChange: defaultProps.onChange,
-      onBlur: instance.onFocusChange,
       onFocus:instance.onFocusChange,
       type: 'text',
       value: defaultProps.value
@@ -59,10 +57,7 @@ describe('<SearchInput />', () => {
 
   it('correctly reports its focus state', () => {
     component.simulate('focus', { type: 'focus' });
-    expect(focusSpy.calledWith(true)).to.be.true;
-
-    component.simulate('blur', { type: 'blur' });
-    expect(focusSpy.calledWith(false)).to.be.true;
+    expect(focusSpy.calledOnce).to.be.true;
   });
 
   // pending until I figure out the correct way to test this

--- a/spec/src/typeahead.spec.js
+++ b/spec/src/typeahead.spec.js
@@ -230,15 +230,27 @@ describe('<Typeahead />', () => {
       });
 
       describe('key bindings', () => {
-        it('responds to ESC by losing focus and hiding results list', () => {
-          const escKeyPressEvent = stubKeyPressEvent(KeyCodes.ESC);
-
+        beforeEach(() => {
           component.setState({
             inputFocused: true,
             showResults: true
           });
           component.update();
+        });
 
+        it('responds to TAB by losing focus', () => {
+          const tabKeyPressEvent = stubKeyPressEvent(KeyCodes.TAB);
+          const unfocusSpy = spy(component.instance(), 'handleUnfocus');
+          component.simulate('keydown', tabKeyPressEvent);
+
+          expect(tabKeyPressEvent.preventDefault.calledOnce).to.be.true;
+          expectStateIsFalsey(component, 'showResults');
+          expectStateIsFalsey(component, 'inputFocused');
+          expect(unfocusSpy.calledOnce).to.be.true;
+        });
+
+        it('responds to ESC by losing focus and hiding results list', () => {
+          const escKeyPressEvent = stubKeyPressEvent(KeyCodes.ESC);
           component.simulate('keydown', escKeyPressEvent);
 
           expect(escKeyPressEvent.preventDefault.calledOnce).to.be.true;
@@ -249,13 +261,6 @@ describe('<Typeahead />', () => {
         it('responds to ENTER by selected the focused element', () => {
           const downKeyPressEvent = stubKeyPressEvent(KeyCodes.DOWN);
           const enterKeyPressEvent = stubKeyPressEvent(KeyCodes.ENTER);
-
-          component.setState({
-            inputFocused: true,
-            showResults: true
-          });
-          component.update();
-
           component.simulate('keydown', downKeyPressEvent);
           component.simulate('keydown', enterKeyPressEvent);
 
@@ -387,7 +392,6 @@ describe('<Typeahead />', () => {
         doAutoFocus: instance.props.autofocus,
         isFocused: instance.state.inputFocused,
         name: defaultSearchName,
-        onBlur: instance.handleUnfocus,
         onFocus: instance.handleInputFocus,
         onKeyInput: instance.handleKeyInput,
         onUnselect: instance.handleUnselect,

--- a/spec/src/utils/key-codes.spec.js
+++ b/spec/src/utils/key-codes.spec.js
@@ -6,5 +6,7 @@ describe('KeyCodes', () => {
     expect(KeyCodes.ESC).to.equal(27);
     expect(KeyCodes.DOWN).to.equal(40);
     expect(KeyCodes.UP).to.equal(38);
+    expect(KeyCodes.TAB).to.equal(9);
+    expect(KeyCodes.ENTER).to.equal(13);
   });
 });

--- a/src/search-bar.js
+++ b/src/search-bar.js
@@ -100,7 +100,6 @@ class SearchBar extends React.Component {
           autoFocus={ doAutoFocus }
           isFocused={ this.props.isFocused }
           name={ name }
-          onBlur={ this.props.onFocus }
           onFocus={ this.props.onFocus }
           onChange={ this.handleKeyInput }
           value={ this.props.query }

--- a/src/search-input.js
+++ b/src/search-input.js
@@ -14,6 +14,8 @@ class SearchInput extends React.Component {
   constructor(props) {
     super(props);
 
+    this.state = { focused: false }
+
     this.onFocusChange = this.onFocusChange.bind(this);
   }
 
@@ -28,13 +30,9 @@ class SearchInput extends React.Component {
     }
   }
 
-  onFocusChange(event) {
-    let type;
-
-    if (event.type === 'focus') {
-      this.props.onFocus(true, event);
-    } else if (event.type === 'blur') {
-      this.props.onFocus(false, event);
+  onFocusChange() {
+    if (!this.props.isFocused) {
+      this.props.onFocus();
     }
   }
 
@@ -45,7 +43,6 @@ class SearchInput extends React.Component {
         autoFocus={ this.props.doAutoFocus }
         className="reactahead-inline-input"
         name={ this.props.name }
-        onBlur={ this.onFocusChange }
         onChange={ this.props.onChange }
         onFocus={ this.onFocusChange }
         type="text"

--- a/src/typeahead.js
+++ b/src/typeahead.js
@@ -99,6 +99,10 @@ class Typeahead extends React.Component {
         event.preventDefault();
         this.handleUnfocus();
         break;
+      case KeyCodes.TAB:
+        event.preventDefault();
+        this.handleUnfocus();
+        break;
       case KeyCodes.UP:
         event.preventDefault();
         this.setResultFocus(-1);
@@ -185,7 +189,7 @@ class Typeahead extends React.Component {
         // so we don't want to hide the results list
         next = null;
 
-        return this.handleInputFocus(true, event);
+        return this.handleInputFocus();
       } else {
         count += 1;
       }
@@ -252,13 +256,9 @@ class Typeahead extends React.Component {
     });
   }
 
-  handleInputFocus(focused, event) {
-    if (this.state.inputFocused && focused) {
-      return;
-    }
-
+  handleInputFocus() {
     this.setState({
-      inputFocused: focused
+      inputFocused: true
     });
   }
 
@@ -322,7 +322,6 @@ class Typeahead extends React.Component {
           isFocused={ state.inputFocused }
           name={ this.props.fieldName || defaultSearchName }
           onFocus={ this.handleInputFocus }
-          onBlur={ this.handleUnfocus }
           onKeyInput={ handleKeyInput }
           onUnselect={this.handleUnselect}
           query={ this.state.query }

--- a/src/utils/key-codes.js
+++ b/src/utils/key-codes.js
@@ -2,5 +2,6 @@ export default {
   ESC: 27,
   UP: 38,
   DOWN: 40,
-  ENTER: 13
+  ENTER: 13,
+  TAB: 9
 };


### PR DESCRIPTION
Blur events are annoying to handle, since they fire before any other
events. Manually handle blurring by just listening to tab events on the
top level typeahead component