### PR TITLE
Move logic to detect if event emitted from child

### DIFF
--- a/src/typeahead.js
+++ b/src/typeahead.js
@@ -5,6 +5,7 @@ import Label from './label';
 import SearchBar from './search-bar';
 import SearchResults from './search-results';
 import defaultFilter from './utils/generic-filter';
+import eventFromChildNode from './utils/event-from-child-node';
 
 /**
  * TODO:
@@ -18,9 +19,6 @@ import defaultFilter from './utils/generic-filter';
  * need to make all labels configurable I guess
  * add 'type to search' help text
  * get this into its own repo with css to be included
- *
- * BUGS:
- * User should not be able to select 'no results match that query' fallback
 */
 
 const propTypes = {
@@ -172,32 +170,12 @@ class Typeahead extends React.Component {
   }
 
   handleClick(event) {
-    const findNextParent = (node) => {
-      return node.parentNode;
-    };
-
-    const stop = 10;
-    let count = 0;
-    let next = event.target;
-
-    while(next = findNextParent(next)) {
-      // bail out early, hide the results list
-      if (count === stop) {
-        break;
-      }
-
-      if (next === nodeOf(this)) {
-        // the node emitting the blur event is a child of the parent node,
-        // so we don't want to hide the results list
-        next = null;
-
-        return this.handleInputFocus();
-      } else {
-        count += 1;
-      }
-    }
-
-    this.handleUnfocus();
+    eventFromChildNode(
+      nodeOf(this),
+      event.target,
+      this.handleInputFocus,
+      this.handleUnfocus
+    );
   }
 
   handleKeyInput(value) {

--- a/src/utils/event-from-child-node.js
+++ b/src/utils/event-from-child-node.js
@@ -1,0 +1,28 @@
+// Determines if a DOM event was fired from a child node of the supplied
+// DOM node
+import nextParentNode from './next-parent-node';
+
+const eventFromChildNode = (parent, node, fromInsideFn, fromOutsideFn, depth=10) => {
+  let count = 0;
+  let next = node;
+
+  while(next = nextParentNode(next)) {
+    // bail out and trigger the fromOutside callback
+    if (count === depth) {
+      break;
+    }
+
+    if (next === parent) {
+      // the node emitting the event is a child of the parent node
+      next = null;
+
+      return fromInsideFn();
+    } else {
+      count += 1;
+    }
+  }
+
+  fromOutsideFn();
+};
+
+export default eventFromChildNode;

--- a/src/utils/next-parent-node.js
+++ b/src/utils/next-parent-node.js
@@ -1,0 +1,3 @@
+const nextParentNode = node => node.parentNode;
+
+export default nextParentNode;


### PR DESCRIPTION
Previously the typeahead component had logic to detect if an event was
emitted from one of its child nodes. This behavior is generic enough to
warrant its own separate utility function